### PR TITLE
Support tree hierarchy in pages list

### DIFF
--- a/inc/class-group.php
+++ b/inc/class-group.php
@@ -60,6 +60,26 @@ class Group {
 	 * @return Page|null Page if set, null otherwise.
 	 */
 	public function get_page( $id ) : ?Page {
-		return $this->pages[ $id ] ?? null;
+		/*
+		Parse IDs with slashes to be sub pages. code-review/process.md means
+		"get the page with id: code-review, then get a subpage of code-review with id: process.md"
+		*/
+		$parts = explode( '/', $id );
+		$id    = array_shift( $parts );
+		$page  = $this->pages[ $id ] ?? null;
+
+		if ( ! $page ) {
+			return null;
+		}
+
+		$current_path = $id;
+		// Crawl through all the url parts (seperated by /) to get the
+		// sub page from the parent at each step.
+		while ( $sub_page_id = array_shift( $parts ) ) {
+			$current_path = $current_path . '/' . $sub_page_id;
+			$page = $page->get_sub_page( $current_path );
+		}
+
+		return $page;
 	}
 }

--- a/inc/class-group.php
+++ b/inc/class-group.php
@@ -63,7 +63,6 @@ class Group {
 		// Parse IDs with slashes to be sub pages. code-review/process.md means
 		// "get the page with id: code-review, then get a sub page of code-review
 		// with id: process.md"
-		*/
 		$parts = explode( '/', $id );
 		$id    = array_shift( $parts );
 		$page  = $this->pages[ $id ] ?? null;

--- a/inc/class-group.php
+++ b/inc/class-group.php
@@ -60,9 +60,9 @@ class Group {
 	 * @return Page|null Page if set, null otherwise.
 	 */
 	public function get_page( $id ) : ?Page {
-		/*
-		Parse IDs with slashes to be sub pages. code-review/process.md means
-		"get the page with id: code-review, then get a subpage of code-review with id: process.md"
+		// Parse IDs with slashes to be sub pages. code-review/process.md means
+		// "get the page with id: code-review, then get a sub page of code-review
+		// with id: process.md"
 		*/
 		$parts = explode( '/', $id );
 		$id    = array_shift( $parts );

--- a/inc/class-group.php
+++ b/inc/class-group.php
@@ -60,8 +60,8 @@ class Group {
 	 * @return Page|null Page if set, null otherwise.
 	 */
 	public function get_page( $id ) : ?Page {
-		// Parse IDs with slashes to be sub pages. code-review/process.md means
-		// "get the page with id: code-review, then get a sub page of code-review
+		// Parse IDs with slashes to be subpages. code-review/process.md means
+		// "get the page with id: code-review, then get a subpage of code-review
 		// with id: process.md"
 		$parts = explode( '/', $id );
 		$id    = array_shift( $parts );
@@ -73,10 +73,10 @@ class Group {
 
 		$current_path = $id;
 		// Crawl through all the url parts (seperated by /) to get the
-		// sub page from the parent at each step.
-		while ( $sub_page_id = array_shift( $parts ) ) {
-			$current_path = $current_path . '/' . $sub_page_id;
-			$page = $page->get_sub_page( $current_path );
+		// subpage from the parent at each step.
+		while ( $subpage_id = array_shift( $parts ) ) {
+			$current_path = $current_path . '/' . $subpage_id;
+			$page = $page->get_subpage( $current_path );
 		}
 
 		return $page;

--- a/inc/class-page.php
+++ b/inc/class-page.php
@@ -23,11 +23,11 @@ class Page {
 	protected $meta;
 
 	/**
-	 * Sub pages of the
+	 * Subpages of the page.
 	 *
 	 * @param Page[]
 	 */
-	protected $sub_pages = [];
+	protected $subpages = [];
 	/**
 	 * Constructor.
 	 *
@@ -79,13 +79,13 @@ class Page {
 	}
 
 	/**
-	 * Add sub page to the page.
+	 * Add subpage to the page.
 	 *
 	 * @param string $id Page ID
 	 * @param Page $page
 	 */
-	public function add_sub_page( string $id, Page $page ) {
-		$this->sub_pages[ $id ] = $page;
+	public function add_subpage( string $id, Page $page ) {
+		$this->subpages[ $id ] = $page;
 	}
 
 	/**
@@ -93,16 +93,16 @@ class Page {
 	 *
 	 * @return Page[]
 	 */
-	public function get_sub_pages() : array {
-		return $this->sub_pages;
+	public function get_subpages() : array {
+		return $this->subpages;
 	}
 
 	/**
-	 * Get a single sub page by ID.
+	 * Get a single subpage by ID.
 	 *
 	 * @return Page|null Page if set, null otherwise.
 	 */
-	public function get_sub_page( string $id ) : ?Page {
-		return $this->sub_pages[ $id ] ?? null;
+	public function get_subpage( string $id ) : ?Page {
+		return $this->subpages[ $id ] ?? null;
 	}
 }

--- a/inc/class-page.php
+++ b/inc/class-page.php
@@ -28,6 +28,7 @@ class Page {
 	 * @param Page[]
 	 */
 	protected $subpages = [];
+
 	/**
 	 * Constructor.
 	 *

--- a/inc/class-page.php
+++ b/inc/class-page.php
@@ -23,6 +23,12 @@ class Page {
 	protected $meta;
 
 	/**
+	 * Sub pages of the
+	 *
+	 * @param Page[]
+	 */
+	protected $sub_pages = [];
+	/**
 	 * Constructor.
 	 *
 	 * @param string $content Raw content of the page
@@ -70,5 +76,33 @@ class Page {
 
 	public function set_meta( string $key, $value ) {
 		$this->meta[ $key ] = $value;
+	}
+
+	/**
+	 * Add sub page to the page.
+	 *
+	 * @param string $id Page ID
+	 * @param Page $page
+	 */
+	public function add_sub_page( string $id, Page $page ) {
+		$this->sub_pages[ $id ] = $page;
+	}
+
+	/**
+	 * Get all pages which belong to the page.
+	 *
+	 * @return Page[]
+	 */
+	public function get_sub_pages() : array {
+		return $this->sub_pages;
+	}
+
+	/**
+	 * Get a single sub page by ID.
+	 *
+	 * @return Page|null Page if set, null otherwise.
+	 */
+	public function get_sub_page( string $id ) : ?Page {
+		return $this->sub_pages[ $id ] ?? null;
 	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -3,7 +3,6 @@
 namespace HM\Platform\Documentation;
 
 use DirectoryIterator;
-use FilesystemIterator;
 use HM\Platform\Module;
 use Spyc;
 
@@ -127,7 +126,7 @@ function get_page_for_dir( string $dir, string $root_dir ) : Page {
 			}
 			// Recurse directories, recursively calling this function
 			$sub_page = get_page_for_dir( $leaf->getPathname(), $root_dir );
-		} else if ( $leaf->getFilename() === 'README.md' ) {
+		} elseif ( $leaf->getFilename() === 'README.md' ) {
 			continue;
 		} else {
 			$sub_page = parse_file( $leaf->getPathname() );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -130,8 +130,8 @@ function get_page_for_dir( string $dir, string $root_dir ) : Page {
 			continue;
 		} else {
 			$subpage = parse_file( $leaf->getPathname() );
-
 		}
+
 		$doc->add_subpage( get_slug_from_path( $root_dir, $leaf->getPathname() ), $subpage );
 	}
 	return $doc;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -84,7 +84,7 @@ function generate_docs_for_module( $id, Module $module ) : ?Group {
 			if ( $leaf->isDot() ) {
 				continue;
 			}
-			// Special handling for sub dirs, to add a page (and sub pages).
+			// Special handling for sub dirs, to add a page (and subpages).
 			$doc = get_page_for_dir( $leaf->getPathname(), $doc_dir );
 			$group->add_page( get_slug_from_path( $doc_dir, $leaf->getPathname() ), $doc );
 			continue;
@@ -107,7 +107,7 @@ function generate_docs_for_module( $id, Module $module ) : ?Group {
 /**
  * Get a page for a given directory.
  *
- * This will recurse into sub directories, adding all those as sub pages of the Page object.
+ * This will recurse into sub directories, adding all those as subpages of the Page object.
  *
  * @param string $dir       The directory to add the page for.
  * @param string $root_dir  The root directory of the group, used to calculate page ids.
@@ -125,14 +125,14 @@ function get_page_for_dir( string $dir, string $root_dir ) : Page {
 				continue;
 			}
 			// Recurse directories, recursively calling this function
-			$sub_page = get_page_for_dir( $leaf->getPathname(), $root_dir );
+			$subpage = get_page_for_dir( $leaf->getPathname(), $root_dir );
 		} elseif ( $leaf->getFilename() === 'README.md' ) {
 			continue;
 		} else {
-			$sub_page = parse_file( $leaf->getPathname() );
+			$subpage = parse_file( $leaf->getPathname() );
 
 		}
-		$doc->add_sub_page( get_slug_from_path( $root_dir, $leaf->getPathname() ), $sub_page );
+		$doc->add_subpage( get_slug_from_path( $root_dir, $leaf->getPathname() ), $subpage );
 	}
 	return $doc;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -2,15 +2,12 @@
 
 namespace HM\Platform\Documentation;
 
+use DirectoryIterator;
 use FilesystemIterator;
 use HM\Platform\Module;
-use Parsedown;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use Spyc;
 
 const CACHE_GROUP = 'platform_documentation';
-const ITERATOR_FLAGS = FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::SKIP_DOTS;
 
 /**
  * Register module.
@@ -79,14 +76,19 @@ function generate_docs_for_module( $id, Module $module ) : ?Group {
 	$group = new Group( $module->get_title() );
 
 	// Generate objects for each file.
-	$iterator = new RecursiveIteratorIterator(
-		new RecursiveDirectoryIterator(
-			$doc_dir,
-			ITERATOR_FLAGS
-		)
-	);
+	$iterator = new DirectoryIterator( $doc_dir );
 	foreach ( $iterator as $leaf ) {
 		/** @var \SplFileInfo $leaf */
+		if ( $leaf->isDir() ) {
+			if ( $leaf->isDot() ) {
+				continue;
+			}
+			// Special handling for sub dirs, to add a page (and sub pages).
+			$doc = get_page_for_dir( $leaf->getPathname(), $doc_dir );
+			$group->add_page( get_slug_from_path( $doc_dir, $leaf->getPathname() ), $doc );
+			continue;
+		}
+
 		if ( $leaf->getExtension() !== 'md' ) {
 			continue;
 		}
@@ -99,6 +101,39 @@ function generate_docs_for_module( $id, Module $module ) : ?Group {
 	}
 
 	return $group;
+}
+
+/**
+ * Get a page for a given directory.
+ *
+ * This will recurse into sub directories, adding all those as sub pages of the Page object.
+ *
+ * @param string $dir       The directory to add the page for.
+ * @param string $root_dir  The root directory of the group, used to calculate page ids.
+ * @return Page
+ */
+function get_page_for_dir( string $dir, string $root_dir ) : Page {
+	// A directory's page is always build from a README.md inside the dir.
+	$doc = parse_file( $dir . '/README.md' );
+
+	$iterator = new DirectoryIterator( $dir );
+	foreach ( $iterator as $leaf ) {
+		/** @var \SplFileInfo $leaf */
+		if ( $leaf->isDir() ) {
+			if ( $leaf->isDot() ) {
+				continue;
+			}
+			// Recurse directories, recursively calling this function
+			$sub_page = get_page_for_dir( $leaf->getPathname(), $root_dir );
+		} else if ( $leaf->getFilename() === 'README.md' ) {
+			continue;
+		} else {
+			$sub_page = parse_file( $leaf->getPathname() );
+
+		}
+		$doc->add_sub_page( get_slug_from_path( $root_dir, $leaf->getPathname() ), $sub_page );
+	}
+	return $doc;
 }
 
 /**

--- a/inc/ui/namespace.php
+++ b/inc/ui/namespace.php
@@ -120,12 +120,12 @@ function render_page_subpages( Page $page, string $group ) {
 				'id' => $subpage_id,
 			] );
 			?>
-		<li>
-			<a href="<?php echo esc_url( $permalink ) ?>">
-				<?php echo esc_html( $subpage->get_meta( 'title' ) ) ?>
-			</a>
-			<?php render_page_subpages( $subpage, $group ) ?>
-		</li>
+			<li>
+				<a href="<?php echo esc_url( $permalink ) ?>">
+					<?php echo esc_html( $subpage->get_meta( 'title' ) ) ?>
+				</a>
+				<?php render_page_subpages( $subpage, $group ) ?>
+			</li>
 		<?php endforeach ?>
 	</ul>
 	<?php

--- a/inc/ui/namespace.php
+++ b/inc/ui/namespace.php
@@ -75,7 +75,7 @@ function render_page() {
 											<?php echo esc_html( $page->get_meta( 'title' ) ) ?>
 										</a>
 									</li>
-									<?php render_page_sub_pages( $page, $group ) ?>
+									<?php render_page_subpages( $page, $group ) ?>
 								<?php endforeach ?>
 							</ul>
 						</li>
@@ -102,29 +102,29 @@ function render_page() {
 /**
  * Output the menu for a page's subp ages.
  *
- * This recurses all sub pages.
+ * This recurses all subpages.
  *
  * @param Page $page
  * @param string $group
  */
-function render_page_sub_pages( Page $page, string $group ) {
-	if ( ! $page->get_sub_pages() ) {
+function render_page_subpages( Page $page, string $group ) {
+	if ( ! $page->get_subpages() ) {
 		return;
 	}
 	?>
 	<ul>
 		<?php
-		foreach ( $page->get_sub_pages() as $sub_page_id => $sub_page ) :
+		foreach ( $page->get_subpages() as $subpage_id => $subpage ) :
 			$permalink = add_query_arg( [
 				'group' => $group,
-				'id' => $sub_page_id,
+				'id' => $subpage_id,
 			] );
 			?>
 		<li>
 			<a href="<?php echo esc_url( $permalink ) ?>">
-				<?php echo esc_html( $sub_page->get_meta( 'title' ) ) ?>
+				<?php echo esc_html( $subpage->get_meta( 'title' ) ) ?>
 			</a>
-			<?php render_page_sub_pages( $sub_page, $group ) ?>
+			<?php render_page_subpages( $subpage, $group ) ?>
 		</li>
 		<?php endforeach ?>
 	</ul>

--- a/inc/ui/namespace.php
+++ b/inc/ui/namespace.php
@@ -66,7 +66,9 @@ function render_page() {
 							<ul>
 								<?php
 								foreach ( $gobj->get_pages() as $id => $page ) :
-									if ( $id === '' ) continue;
+									if ( $id === '' ) {
+										continue;
+									}
 									?>
 									<li>
 										<a href="<?php echo add_query_arg( compact( 'group', 'id' ) ) ?>">
@@ -111,9 +113,12 @@ function render_page_sub_pages( Page $page, string $group ) {
 	}
 	?>
 	<ul>
-		<?php foreach ( $page->get_sub_pages() as $sub_page_id => $sub_page ) : ?>
+		<?php
+		foreach ( $page->get_sub_pages() as $sub_page_id => $sub_page ) :
+			$permalink = add_query_arg( [ 'group' => $group, 'id' => $sub_page_id ] );
+			?>
 		<li>
-			<a href="<?php echo add_query_arg( [ 'group' => $group, 'id' => $sub_page_id ] ) ?>">
+			<a href="<?php echo esc_url( $permalink ) ?>">
 				<?php echo esc_html( $sub_page->get_meta( 'title' ) ) ?>
 			</a>
 			<?php render_page_sub_pages( $sub_page, $group ) ?>

--- a/inc/ui/namespace.php
+++ b/inc/ui/namespace.php
@@ -115,7 +115,10 @@ function render_page_sub_pages( Page $page, string $group ) {
 	<ul>
 		<?php
 		foreach ( $page->get_sub_pages() as $sub_page_id => $sub_page ) :
-			$permalink = add_query_arg( [ 'group' => $group, 'id' => $sub_page_id ] );
+			$permalink = add_query_arg( [
+				'group' => $group,
+				'id' => $sub_page_id,
+			] );
 			?>
 		<li>
 			<a href="<?php echo esc_url( $permalink ) ?>">

--- a/inc/ui/namespace.php
+++ b/inc/ui/namespace.php
@@ -67,12 +67,13 @@ function render_page() {
 								<?php
 								foreach ( $gobj->get_pages() as $id => $page ) :
 									if ( $id === '' ) continue;
-								?>
+									?>
 									<li>
 										<a href="<?php echo add_query_arg( compact( 'group', 'id' ) ) ?>">
 											<?php echo esc_html( $page->get_meta( 'title' ) ) ?>
 										</a>
 									</li>
+									<?php render_page_sub_pages( $page, $group ) ?>
 								<?php endforeach ?>
 							</ul>
 						</li>
@@ -93,6 +94,32 @@ function render_page() {
 		</div>
 	</div>
 
+	<?php
+}
+
+/**
+ * Output the menu for a page's subp ages.
+ *
+ * This recurses all sub pages.
+ *
+ * @param Page $page
+ * @param string $group
+ */
+function render_page_sub_pages( Page $page, string $group ) {
+	if ( ! $page->get_sub_pages() ) {
+		return;
+	}
+	?>
+	<ul>
+		<?php foreach ( $page->get_sub_pages() as $sub_page_id => $sub_page ) : ?>
+		<li>
+			<a href="<?php echo add_query_arg( [ 'group' => $group, 'id' => $sub_page_id ] ) ?>">
+				<?php echo esc_html( $sub_page->get_meta( 'title' ) ) ?>
+			</a>
+			<?php render_page_sub_pages( $sub_page, $group ) ?>
+		</li>
+		<?php endforeach ?>
+	</ul>
 	<?php
 }
 


### PR DESCRIPTION
I implemented this via adding `sub_pages` to the `Page` object, and then uses recursion when adding pages per group. The page IDs of sub pages are stored as their relative path, but then changed `Group::get_page` to recurse getting sub pages based off the `/` delimiter.

Here's an example with multiple levels of directories in the Cloud docs:

![](https://joehoyle-captured.s3.amazonaws.com/lMIHqQJp.png)