### PR TITLE
Add anchor links to all headings

### DIFF
--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -82,8 +82,8 @@ class MarkdownParser extends Parsedown {
 					'href' => '#' . $id,
 					'id' => $id,
 				],
-				'elements' => [ $block ]
-			]
+				'elements' => [ $block ],
+			],
 		];
 	}
 }

--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -63,4 +63,27 @@ class MarkdownParser extends Parsedown {
 
 		return $result;
 	}
+
+	/**
+	 * Parse a header block
+	 *
+	 * Override the blockHeader method to add anchor links.
+	 *
+	 * @param array $data
+	 * @return array
+	 */
+	protected function blockHeader( $data ) {
+		$block = parent::blockHeader( $data );
+		$id = str_replace( ' ', '-', strtolower( strip_tags( $block['element']['handler']['argument'] ) ) );
+		return [
+			'element' => [
+				'name' => 'a',
+				'attributes' => [
+					'href' => '#' . $id,
+					'id' => $id,
+				],
+				'elements' => [ $block ]
+			]
+		];
+	}
 }

--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -74,7 +74,7 @@ class MarkdownParser extends Parsedown {
 	 */
 	protected function blockHeader( $data ) {
 		$block = parent::blockHeader( $data );
-		$id = str_replace( ' ', '-', strtolower( strip_tags( $block['element']['handler']['argument'] ) ) );
+		$id = sanitize_title_with_dashes( $block['element']['handler']['argument'] );
 		return [
 			'element' => [
 				'name' => 'a',


### PR DESCRIPTION
Similar I think to how Markdown handles headings, add an `id` attribute and link, so people can easily "copy link location" and follow links to a specific heading on the page.