### PR TITLE
Add check for add_action

### DIFF
--- a/load.php
+++ b/load.php
@@ -7,4 +7,9 @@ const DIRECTORY = __DIR__;
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/ui/namespace.php';
 
+// Don't self-initialize if this is not a Platform execution.
+if ( ! function_exists( 'add_action' ) ) {
+	return;
+}
+
 add_action( 'hm-platform.modules.init', __NAMESPACE__ . '\\register' );


### PR DESCRIPTION
Per https://github.com/humanmade/platform-dev/issues/323, we are screwing up any inclusion of autoload.php outside of the wp-config.php. We are discussing a better long term solution in https://github.com/humanmade/platform-dev/pull/325, but this is intended to get things functioning.