### PR TITLE
Add ability to cross-link between documentation groups

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+The Documentation module provides documentation for Platform.

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -1,0 +1,43 @@
+# Linking
+
+The Documentation module supports relative links and cross-linking between pages in documentation.
+
+
+## Relative Links
+
+Within a given module's documentation, you can use relative links between files. These will be resolved during the rendering of the documentation.
+
+For example, to link to a document in the same directory called `doc.md`, you can format your link as:
+
+```md
+Consult the [documentation](./doc.md)
+```
+
+To link to a document in a subdirectory or a parent directory, use similar relative links with the directory names:
+
+```md
+[Document in the parent directory](../doc.md)
+
+[Document in a subdirectory](./subdir/doc.md)
+```
+
+Note that relative links can only be used between documents in a single module, and links to other modules should instead use cross-linking.
+
+
+## Cross-Linking
+
+Cross-linking refers to links from one module to another. This allows creating richer documentation, tying together various modules.
+
+To link from one module to another, use the special URL scheme `docs://`. This should be followed by the name of the documentation group (typically the module ID), followed by a slash, followed by the page ID (typically a file path within the module's documentation directory). The full format is:
+
+```
+docs://{group}/{id}
+```
+
+For example, to link to the `branding.md` document in the CMS module (ID `cms`):
+
+```md
+Consult the [branding documentation](docs://cms/branding.md)
+```
+
+**Note:** while documentation group IDs generally align with module IDs, some special groups exist for meta documentation. This includes the Getting Started (ID `getting-started`) and Guides (ID `guides`) documentation, which are located in the `other-docs` directory of the Documentation module.

--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -62,7 +62,7 @@ class MarkdownParser extends Parsedown {
 
 		// Override href.
 		$slug = get_slug_from_path( $root, $resolved );
-		$url = add_query_arg( [ 'id' => urlencode( $slug ) ] );
+		$url = get_url_for_page( UI\get_current_group_id(), $slug );
 		$result['element']['attributes']['href'] = $url;
 
 		return $result;
@@ -84,10 +84,7 @@ class MarkdownParser extends Parsedown {
 
 		// Override href.
 		$slug = get_slug_from_path( '', $path );
-		$url = add_query_arg( [
-			'group' => urlencode( $group ),
-			'id' => urlencode( $slug ),
-		] );
+		$url = get_url_for_page( $group, $slug );
 		$result['element']['attributes']['href'] = $url;
 
 		return $result;

--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -44,6 +44,10 @@ class MarkdownParser extends Parsedown {
 
 		// Is the link relative?
 		$parts = wp_parse_url( $href );
+		if ( ! empty( $parts['scheme'] ) && $parts['scheme'] === 'docs' ) {
+			return $this->inlineInternalLink( $result, $parts );
+		}
+
 		if ( ! empty( $parts['host'] ) ) {
 			return $result;
 		}
@@ -59,6 +63,31 @@ class MarkdownParser extends Parsedown {
 		// Override href.
 		$slug = get_slug_from_path( $root, $resolved );
 		$url = add_query_arg( [ 'id' => urlencode( $slug ) ] );
+		$result['element']['attributes']['href'] = $url;
+
+		return $result;
+	}
+
+	/**
+	 * Generate an internal link to another module.
+	 *
+	 * This handles generating links across modules. It transforms links in
+	 * the format `docs://group/id` to `?group=&id=` internal URLs.
+	 *
+	 * @param array $result Parsed result from parent::inlineLink
+	 * @param array $parts Parsed data from the link's HREF
+	 * @return array Result with modified URL
+	 */
+	protected function inlineInternalLink( $result, $parts ) {
+		$group = $parts['host'];
+		$path = $parts['path'];
+
+		// Override href.
+		$slug = get_slug_from_path( '', $path );
+		$url = add_query_arg( [
+			'group' => urlencode( $group ),
+			'id' => urlencode( $slug ),
+		] );
 		$result['element']['attributes']['href'] = $url;
 
 		return $result;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -237,3 +237,29 @@ function render_page( Page $page ) : string {
 	$parsedown = new MarkdownParser( $page );
 	return $parsedown->text( $page->get_content() );
 }
+
+/**
+ * Get the URL to view a given page.
+ *
+ * @param string $group_id Group ID.
+ * @param string $page_id Page ID.
+ * @return string Absolute URL to the page.
+ */
+function get_url_for_page( $group_id, $page_id ) {
+	$base_url = admin_url( 'admin.php' );
+	$args = [
+		'page' => UI\PAGE_SLUG,
+		'group' => $group_id,
+		'id' => $page_id,
+	];
+	$url = add_query_arg( urlencode_deep( $args ), $base_url );
+
+	/**
+	 * Filter generated URL for a page.
+	 *
+	 * @param string $url Default generated URL.
+	 * @param string $group_id Group ID.
+	 * @param string $page_id Page ID.
+	 */
+	return apply_filters( 'hm-platform.documentation.url_for_page', $url, $group_id, $page_id );
+}

--- a/inc/ui/namespace.php
+++ b/inc/ui/namespace.php
@@ -6,6 +6,8 @@ use HM\Platform\Documentation;
 use HM\Platform\Documentation\Page;
 use WP_Admin_Bar;
 
+const PAGE_SLUG = 'hm-platform-documentation';
+
 function bootstrap() {
 	add_action( 'admin_menu', __NAMESPACE__ . '\\register_menu' );
 	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\admin_bar_menu', 11 );
@@ -24,7 +26,7 @@ function register_menu() {
 		'',
 		'',
 		'edit_posts',
-		'hm-platform-documentation',
+		PAGE_SLUG,
 		__NAMESPACE__ . '\\render_page'
 	);
 
@@ -41,7 +43,7 @@ function admin_bar_menu( WP_Admin_Bar $wp_admin_bar ) {
 		'parent' => 'hm-platform',
 		'id'     => 'documentation',
 		'title'  => __( 'Documentation', 'hm-platform' ),
-		'href'   => add_query_arg( 'page', 'hm-platform-documentation', admin_url( 'admin.php' ) ),
+		'href'   => add_query_arg( 'page', PAGE_SLUG, admin_url( 'admin.php' ) ),
 	] );
 }
 


### PR DESCRIPTION
Fixes #17.

I've added a helper function to generate URLs, which is filterable, as we want to generate URLs differently on the public site (cc @joehoyle).

Also adds documentation for this feature, and a stub page for the base of the documentation.