### PR TITLE
Support docs assets dir

### DIFF
--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -54,15 +54,22 @@ class MarkdownParser extends Parsedown {
 
 		// Resolve relative to the current file.
 		$base = $this->current_page->get_meta( 'path' );
-		$root= $this->current_page->get_meta( 'root' );
+		$root = $this->current_page->get_meta( 'root' );
 		$resolved = realpath( path_join( dirname( $base ), $href ) );
 		if ( empty( $resolved ) ) {
 			return $result;
 		}
 
 		// Override href.
-		$slug = get_slug_from_path( $root, $resolved );
-		$url = get_url_for_page( UI\get_current_group_id(), $slug );
+
+		// Support URLs to assets directories in a module's docs directory.
+		if ( strpos( $href, './assets/' ) === 0 ) {
+			$url = plugins_url( $href, $root . '/wp-is-dumb' );
+		} else {
+			$slug = get_slug_from_path( $root, $resolved );
+			$url = get_url_for_page( UI\get_current_group_id(), $slug );
+		}
+
 		$result['element']['attributes']['href'] = $url;
 
 		return $result;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -120,6 +120,9 @@ function add_docs_for_group( Group $group, string $doc_dir ) : Group {
 			if ( $leaf->isDot() ) {
 				continue;
 			}
+			if ( $leaf->getFilename() === 'assets' ) {
+				continue;
+			}
 			// Special handling for sub dirs, to add a page (and subpages).
 			$doc = get_page_for_dir( $leaf->getPathname(), $doc_dir );
 			$group->add_page( get_slug_from_path( $doc_dir, $leaf->getPathname() ), $doc );
@@ -158,6 +161,9 @@ function get_page_for_dir( string $dir, string $root_dir ) : Page {
 		/** @var \SplFileInfo $leaf */
 		if ( $leaf->isDir() ) {
 			if ( $leaf->isDot() ) {
+				continue;
+			}
+			if ( $leaf->getFilename() === 'assets' ) {
 				continue;
 			}
 			// Recurse directories, recursively calling this function


### PR DESCRIPTION
To use things like images in docs, add support for `assets` directories in module's docs folders. This is used by https://github.com/humanmade/platform-cloud/pull/24.