### PR TITLE
Locally cache documentation

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -36,7 +36,7 @@ function bootstrap() {
 function get_documentation() : array {
 	static $documentation;
 
-	if ( $documentation ) {
+	if ( empty( $documentation ) ) {
 		return $documentation;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -36,7 +36,7 @@ function bootstrap() {
 function get_documentation() : array {
 	static $docs;
 
-	if ( empty( $docs ) ) {
+	if ( ! empty( $docs ) ) {
 		return $docs;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,10 +34,10 @@ function bootstrap() {
  * @return Group[] Sorted list of groupse
  */
 function get_documentation() : array {
-	static $documentation;
+	static $docs;
 
-	if ( empty( $documentation ) ) {
-		return $documentation;
+	if ( empty( $docs ) ) {
+		return $docs;
 	}
 
 	$modules = Module::get_all();
@@ -72,7 +72,6 @@ function get_documentation() : array {
 	 */
 	$docs = apply_filters( 'hm-platform.documentation.groups', $docs );
 
-	$documentation = $docs;
 	return $docs;
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,6 +34,12 @@ function bootstrap() {
  * @return Group[] Sorted list of groupse
  */
 function get_documentation() : array {
+	static $documentation;
+
+	if ( $documentation ) {
+		return $documentation;
+	}
+
 	$modules = Module::get_all();
 
 	$getting_started = new Group( 'Getting Started' );
@@ -66,6 +72,7 @@ function get_documentation() : array {
 	 */
 	$docs = apply_filters( 'hm-platform.documentation.groups', $docs );
 
+	$documentation = $docs;
 	return $docs;
 }
 


### PR DESCRIPTION
Cache parsed documentation in memory, for faster re-use, and repeat calling Object equality.

This is at the expense of memory, as the static is not GCed, but I think it's worth it, as we already call this function 2 times per render. Also, this was breaking a comparison on `Page` objects, due to them not being the same object reference for the same page.