### PR TITLE
Support image URLs

### DIFF
--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -28,7 +28,7 @@ class MarkdownParser extends Parsedown {
 	 *
 	 * Overridden to resolve relative URLs based on the current page.
 	 *
-	 * @param mixed $data
+	 * @param mixed $data Raw data from the Markdown tokeniser
 	 * @return array
 	 */
 	protected function inlineImage( $data ) {
@@ -73,7 +73,7 @@ class MarkdownParser extends Parsedown {
 	 *
 	 * Overridden to resolve relative URLs based on the current page.
 	 *
-	 * @param mixed $data
+	 * @param mixed $data Raw data from the Markdown tokeniser
 	 * @return array
 	 */
 	protected function inlineLink( $data ) {

--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -31,7 +31,7 @@ class MarkdownParser extends Parsedown {
 	 * @param mixed $data
 	 * @return array
 	 */
-    protected function inlineLink( $data ) {
+	protected function inlineLink( $data ) {
 		$result = parent::inlineLink( $data );
 		if ( $result['element']['name'] !== 'a' ) {
 			return $result;

--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -54,15 +54,22 @@ class MarkdownParser extends Parsedown {
 
 		// Resolve relative to the current file.
 		$base = $this->current_page->get_meta( 'path' );
-		$root= $this->current_page->get_meta( 'root' );
+		$root = $this->current_page->get_meta( 'root' );
 		$resolved = realpath( path_join( dirname( $base ), $href ) );
 		if ( empty( $resolved ) ) {
 			return $result;
 		}
 
 		// Override href.
-		$slug = get_slug_from_path( $root, $resolved );
-		$url = get_url_for_page( UI\get_current_group_id(), $slug );
+
+		// Support URLs to assets directories in a module's docs directory.
+		if ( strpos( $href, './assets/' ) === 0 ) {
+			$url = plugins_url( $href, $root . '/wp-is-dumb' );
+		} else {
+			$slug = get_slug_from_path( $root, $resolved );
+			$url = get_url_for_page( UI\get_current_group_id(), $slug );
+		}
+
 		$result['element']['attributes']['href'] = $url;
 
 		return $result;

--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -61,15 +61,8 @@ class MarkdownParser extends Parsedown {
 		}
 
 		// Override href.
-
-		// Support URLs to assets directories in a module's docs directory.
-		if ( strpos( $href, './assets/' ) === 0 ) {
-			$url = plugins_url( $href, $root . '/wp-is-dumb' );
-		} else {
-			$slug = get_slug_from_path( $root, $resolved );
-			$url = get_url_for_page( UI\get_current_group_id(), $slug );
-		}
-
+		$slug = get_slug_from_path( $root, $resolved );
+		$url = get_url_for_page( UI\get_current_group_id(), $slug );
 		$result['element']['attributes']['href'] = $url;
 
 		return $result;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -120,6 +120,9 @@ function add_docs_for_group( Group $group, string $doc_dir ) : Group {
 			if ( $leaf->isDot() ) {
 				continue;
 			}
+			if ( $leaf->getFilename() === 'assets' ) {
+				continue;
+			}
 			// Special handling for sub dirs, to add a page (and subpages).
 			$doc = get_page_for_dir( $leaf->getPathname(), $doc_dir );
 			$group->add_page( get_slug_from_path( $doc_dir, $leaf->getPathname() ), $doc );
@@ -158,6 +161,9 @@ function get_page_for_dir( string $dir, string $root_dir ) : Page {
 		/** @var \SplFileInfo $leaf */
 		if ( $leaf->isDir() ) {
 			if ( $leaf->isDot() ) {
+				continue;
+			}
+			if ( $leaf->getFilename() === 'assets' ) {
 				continue;
 			}
 			// Recurse directories, recursively calling this function

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -120,9 +120,7 @@ function add_docs_for_group( Group $group, string $doc_dir ) : Group {
 			if ( $leaf->isDot() ) {
 				continue;
 			}
-			if ( $leaf->getFilename() === 'assets' ) {
-				continue;
-			}
+
 			// Special handling for sub dirs, to add a page (and subpages).
 			$doc = get_page_for_dir( $leaf->getPathname(), $doc_dir );
 			if ( empty( $doc ) ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -125,6 +125,10 @@ function add_docs_for_group( Group $group, string $doc_dir ) : Group {
 			}
 			// Special handling for sub dirs, to add a page (and subpages).
 			$doc = get_page_for_dir( $leaf->getPathname(), $doc_dir );
+			if ( empty( $doc ) ) {
+				continue;
+			}
+
 			$group->add_page( get_slug_from_path( $doc_dir, $leaf->getPathname() ), $doc );
 			continue;
 		}
@@ -150,11 +154,13 @@ function add_docs_for_group( Group $group, string $doc_dir ) : Group {
  *
  * @param string $dir       The directory to add the page for.
  * @param string $root_dir  The root directory of the group, used to calculate page ids.
- * @return Page
+ * @return Page|null
  */
-function get_page_for_dir( string $dir, string $root_dir ) : Page {
+function get_page_for_dir( string $dir, string $root_dir ) : ?Page {
 	// A directory's page is always build from a README.md inside the dir.
-	$doc = parse_file( $dir . '/README.md' );
+	$readme = $dir . '/README.md';
+	$doc = file_exists( $readme ) ? parse_file( $readme ) : new Page( '' );
+	$has_subpages = false;
 
 	$iterator = new DirectoryIterator( $dir );
 	foreach ( $iterator as $leaf ) {
@@ -176,8 +182,15 @@ function get_page_for_dir( string $dir, string $root_dir ) : Page {
 			$subpage = parse_file( $leaf->getPathname() );
 		}
 
+		$has_subpages = true;
 		$doc->add_subpage( get_slug_from_path( $root_dir, $leaf->getPathname() ), $subpage );
 	}
+
+	// If we don't have any actual files, bail.
+	if ( ! file_exists( $readme ) && ! $has_subpages ) {
+		return null;
+	}
+
 	return $doc;
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -168,6 +168,8 @@ function get_page_for_dir( string $dir, string $root_dir ) : Page {
 			}
 			// Recurse directories, recursively calling this function
 			$subpage = get_page_for_dir( $leaf->getPathname(), $root_dir );
+		} elseif ( $leaf->getExtension() !== 'md' ) {
+			continue;
 		} elseif ( $leaf->getFilename() === 'README.md' ) {
 			continue;
 		} else {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -167,11 +167,12 @@ function get_page_for_dir( string $dir, string $root_dir ) : ?Page {
 			if ( $leaf->isDot() ) {
 				continue;
 			}
-			if ( $leaf->getFilename() === 'assets' ) {
-				continue;
-			}
+
 			// Recurse directories, recursively calling this function
 			$subpage = get_page_for_dir( $leaf->getPathname(), $root_dir );
+			if ( empty( $subpage ) ) {
+				continue;
+			}
 		} elseif ( $leaf->getExtension() !== 'md' ) {
 			continue;
 		} elseif ( $leaf->getFilename() === 'README.md' ) {


### PR DESCRIPTION
Obsoletes #31. Rather than special-casing a `assets` directory, this overrides `inlineImage` and allows using any directory as required.

This should be less-brittle long-term, and allows assets to be placed wherever desired. We should stick to `assets/` as a best-practice, but without forcing it here.